### PR TITLE
Add DDFM segmentation example

### DIFF
--- a/README_DDFM.md
+++ b/README_DDFM.md
@@ -1,0 +1,27 @@
+# DDFM for Segmentation
+
+This example extends **MedSegDiff** with a minimal implementation of
+Denoising Diffusion Flow Matching (DDFM). The new diffusion class is
+`guided_diffusion.ddfm.DDFMDiffusion` which currently inherits from
+`SpacedDiffusion`.
+
+The training and sampling scripts are:
+
+- `scripts/ddfm_segmentation_train.py`
+- `scripts/ddfm_segmentation_sample.py`
+
+Both scripts mirror the original `segmentation_*` tools but create a
+DDFM diffusion process using `create_model_and_ddfm` from
+`guided_diffusion.script_util`.
+
+Run training with for example:
+
+```bash
+python scripts/ddfm_segmentation_train.py --data_dir <data> --out_dir <results>
+```
+
+Sampling follows the same pattern:
+
+```bash
+python scripts/ddfm_segmentation_sample.py --data_dir <data> --model_path <ckpt>
+```

--- a/guided_diffusion/__init__.py
+++ b/guided_diffusion/__init__.py
@@ -1,3 +1,4 @@
 """
 Codebase for " Diffusion Models for Implicit Image Segmentation Ensembles".
 """
+from .ddfm import DDFMDiffusion

--- a/guided_diffusion/ddfm.py
+++ b/guided_diffusion/ddfm.py
@@ -1,0 +1,17 @@
+import numpy as np
+import torch as th
+from .respace import SpacedDiffusion
+
+class DDFMDiffusion(SpacedDiffusion):
+    """Denoising Diffusion Flow Matching (DDFM) diffusion process.
+
+    This is a simple extension of :class:`SpacedDiffusion` used to
+    demonstrate how a flow matching variant can be integrated into
+    the segmentation framework. The current implementation behaves
+    identically to :class:`SpacedDiffusion` and can be extended with
+    custom objectives.
+    """
+
+    def training_losses(self, model, *args, **kwargs):
+        # Placeholder for a flow-matching loss.
+        return super().training_losses(model, *args, **kwargs)

--- a/guided_diffusion/script_util.py
+++ b/guided_diffusion/script_util.py
@@ -3,6 +3,7 @@ import inspect
 
 from . import gaussian_diffusion as gd
 from .respace import SpacedDiffusion, space_timesteps
+from .ddfm import DDFMDiffusion
 from .unet import SuperResModel, UNetModel_newpreview, UNetModel_v1preview, EncoderUNetModel
 
 NUM_CLASSES = 2
@@ -131,6 +132,67 @@ def create_model_and_diffusion(
         rescale_timesteps=rescale_timesteps,
         rescale_learned_sigmas=rescale_learned_sigmas,
         dpm_solver=dpm_solver,
+        timestep_respacing=timestep_respacing,
+    )
+    return model, diffusion
+
+
+def create_model_and_ddfm(
+    image_size,
+    class_cond,
+    learn_sigma,
+    num_channels,
+    num_res_blocks,
+    channel_mult,
+    in_ch,
+    num_heads,
+    num_head_channels,
+    num_heads_upsample,
+    attention_resolutions,
+    dropout,
+    diffusion_steps,
+    noise_schedule,
+    timestep_respacing,
+    use_kl,
+    predict_xstart,
+    rescale_timesteps,
+    rescale_learned_sigmas,
+    use_checkpoint,
+    use_scale_shift_norm,
+    resblock_updown,
+    use_fp16,
+    use_new_attention_order,
+    version,
+):
+    """Create a UNet model and a DDFM diffusion process."""
+    model = create_model(
+        image_size,
+        num_channels,
+        num_res_blocks,
+        channel_mult=channel_mult,
+        learn_sigma=learn_sigma,
+        class_cond=class_cond,
+        use_checkpoint=use_checkpoint,
+        attention_resolutions=attention_resolutions,
+        in_ch=in_ch,
+        num_heads=num_heads,
+        num_head_channels=num_head_channels,
+        num_heads_upsample=num_heads_upsample,
+        use_scale_shift_norm=use_scale_shift_norm,
+        dropout=dropout,
+        resblock_updown=resblock_updown,
+        use_fp16=use_fp16,
+        use_new_attention_order=use_new_attention_order,
+        version=version,
+    )
+    diffusion = create_ddfm_diffusion(
+        steps=diffusion_steps,
+        learn_sigma=learn_sigma,
+        noise_schedule=noise_schedule,
+        use_kl=use_kl,
+        predict_xstart=predict_xstart,
+        rescale_timesteps=rescale_timesteps,
+        rescale_learned_sigmas=rescale_learned_sigmas,
         timestep_respacing=timestep_respacing,
     )
     return model, diffusion
@@ -450,6 +512,44 @@ def create_gaussian_diffusion(
         ),
         loss_type=loss_type,
         dpm_solver=dpm_solver,
+        rescale_timesteps=rescale_timesteps,
+    )
+
+
+def create_ddfm_diffusion(
+    *,
+    steps=1000,
+    learn_sigma=False,
+    noise_schedule="linear",
+    use_kl=False,
+    predict_xstart=False,
+    rescale_timesteps=False,
+    rescale_learned_sigmas=False,
+    timestep_respacing="",
+):
+    """Create a :class:`DDFMDiffusion` with settings mirroring ``create_gaussian_diffusion``."""
+    betas = gd.get_named_beta_schedule(noise_schedule, steps)
+    if use_kl:
+        loss_type = gd.LossType.RESCALED_KL
+    elif rescale_learned_sigmas:
+        loss_type = gd.LossType.RESCALED_MSE
+    else:
+        loss_type = gd.LossType.MSE
+    if not timestep_respacing:
+        timestep_respacing = [steps]
+    return DDFMDiffusion(
+        use_timesteps=space_timesteps(steps, timestep_respacing),
+        betas=betas,
+        model_mean_type=(
+            gd.ModelMeanType.EPSILON if not predict_xstart else gd.ModelMeanType.START_X
+        ),
+        model_var_type=(
+            gd.ModelVarType.FIXED_LARGE
+            if not learn_sigma
+            else gd.ModelVarType.LEARNED_RANGE
+        ),
+        loss_type=loss_type,
+        dpm_solver=False,
         rescale_timesteps=rescale_timesteps,
     )
 

--- a/scripts/ddfm_segmentation_sample.py
+++ b/scripts/ddfm_segmentation_sample.py
@@ -1,0 +1,199 @@
+
+
+import argparse
+import os
+from ssl import OP_NO_TLSv1
+import nibabel as nib
+# from visdom import Visdom
+# viz = Visdom(port=8850)
+import sys
+import random
+sys.path.append(".")
+import numpy as np
+import time
+import torch as th
+from PIL import Image
+import torch.distributed as dist
+from guided_diffusion import dist_util, logger
+from guided_diffusion.bratsloader import BRATSDataset, BRATSDataset3D
+from guided_diffusion.isicloader import ISICDataset
+from guided_diffusion.custom_dataset_loader import CustomDataset
+import torchvision.utils as vutils
+from guided_diffusion.utils import staple
+from guided_diffusion.script_util import (
+    NUM_CLASSES,
+    model_and_diffusion_defaults,
+    create_model_and_ddfm,
+    add_dict_to_argparser,
+    args_to_dict,
+)
+import torchvision.transforms as transforms
+from torchsummary import summary
+seed=10
+th.manual_seed(seed)
+th.cuda.manual_seed_all(seed)
+np.random.seed(seed)
+random.seed(seed)
+
+def visualize(img):
+    _min = img.min()
+    _max = img.max()
+    normalized_img = (img - _min)/ (_max - _min)
+    return normalized_img
+
+
+def main():
+    args = create_argparser().parse_args()
+    dist_util.setup_dist(args)
+    logger.configure(dir = args.out_dir)
+
+    if args.data_name == 'ISIC':
+        tran_list = [transforms.Resize((args.image_size,args.image_size)), transforms.ToTensor(),]
+        transform_test = transforms.Compose(tran_list)
+
+        ds = ISICDataset(args, args.data_dir, transform_test, mode = 'Test')
+        args.in_ch = 4
+    elif args.data_name == 'BRATS':
+        tran_list = [transforms.Resize((args.image_size,args.image_size)),]
+        transform_test = transforms.Compose(tran_list)
+
+        ds = BRATSDataset3D(args.data_dir,transform_test)
+        args.in_ch = 5
+    else:
+        tran_list = [transforms.Resize((args.image_size,args.image_size)), transforms.ToTensor()]
+        transform_test = transforms.Compose(tran_list)
+
+        ds = CustomDataset(args, args.data_dir, transform_test, mode = 'Test')
+        args.in_ch = 4
+
+    datal = th.utils.data.DataLoader(
+        ds,
+        batch_size=args.batch_size,
+        shuffle=True)
+    data = iter(datal)
+
+    logger.log("creating model and diffusion...")
+
+    model, diffusion = create_model_and_ddfm(
+        **args_to_dict(args, model_and_diffusion_defaults().keys())
+    )
+    all_images = []
+
+
+    state_dict = dist_util.load_state_dict(args.model_path, map_location="cpu")
+    from collections import OrderedDict
+    new_state_dict = OrderedDict()
+    for k, v in state_dict.items():
+        # name = k[7:] # remove `module.`
+        if 'module.' in k:
+            new_state_dict[k[7:]] = v
+            # load params
+        else:
+            new_state_dict = state_dict
+
+    model.load_state_dict(new_state_dict)
+
+    model.to(dist_util.dev())
+    if args.use_fp16:
+        model.convert_to_fp16()
+    model.eval()
+    for _ in range(len(data)):
+        b, m, path = next(data)  #should return an image from the dataloader "data"
+        c = th.randn_like(b[:, :1, ...])
+        img = th.cat((b, c), dim=1)     #add a noise channel$
+        if args.data_name == 'ISIC':
+            slice_ID=path[0].split("_")[-1].split('.')[0]
+        elif args.data_name == 'BRATS':
+            # slice_ID=path[0].split("_")[2] + "_" + path[0].split("_")[4]
+            slice_ID=path[0].split("_")[-3] + "_" + path[0].split("slice")[-1].split('.nii')[0]
+
+        logger.log("sampling...")
+
+        start = th.cuda.Event(enable_timing=True)
+        end = th.cuda.Event(enable_timing=True)
+        enslist = []
+
+        for i in range(args.num_ensemble):  #this is for the generation of an ensemble of 5 masks.
+            model_kwargs = {}
+            start.record()
+            sample_fn = (
+                diffusion.p_sample_loop_known if not args.use_ddim else diffusion.ddim_sample_loop_known
+            )
+            sample, x_noisy, org, cal, cal_out = sample_fn(
+                model,
+                (args.batch_size, 3, args.image_size, args.image_size), img,
+                step = args.diffusion_steps,
+                clip_denoised=args.clip_denoised,
+                model_kwargs=model_kwargs,
+            )
+
+            end.record()
+            th.cuda.synchronize()
+            print('time for 1 sample', start.elapsed_time(end))  #time measurement for the generation of 1 sample
+
+            co = th.tensor(cal_out)
+            if args.version == 'new':
+                enslist.append(sample[:,-1,:,:])
+            else:
+                enslist.append(co)
+
+            if args.debug:
+                # print('sample size is',sample.size())
+                # print('org size is',org.size())
+                # print('cal size is',cal.size())
+                if args.data_name == 'ISIC':
+                    # s = th.tensor(sample)[:,-1,:,:].unsqueeze(1).repeat(1, 3, 1, 1)
+                    o = th.tensor(org)[:,:-1,:,:]
+                    c = th.tensor(cal).repeat(1, 3, 1, 1)
+                    # co = co.repeat(1, 3, 1, 1)
+
+                    s = sample[:,-1,:,:]
+                    b,h,w = s.size()
+                    ss = s.clone()
+                    ss = ss.view(s.size(0), -1)
+                    ss -= ss.min(1, keepdim=True)[0]
+                    ss /= ss.max(1, keepdim=True)[0]
+                    ss = ss.view(b, h, w)
+                    ss = ss.unsqueeze(1).repeat(1, 3, 1, 1)
+
+                    tup = (ss,o,c)
+                elif args.data_name == 'BRATS':
+                    s = th.tensor(sample)[:,-1,:,:].unsqueeze(1)
+                    m = th.tensor(m.to(device = 'cuda:0'))[:,0,:,:].unsqueeze(1)
+                    o1 = th.tensor(org)[:,0,:,:].unsqueeze(1)
+                    o2 = th.tensor(org)[:,1,:,:].unsqueeze(1)
+                    o3 = th.tensor(org)[:,2,:,:].unsqueeze(1)
+                    o4 = th.tensor(org)[:,3,:,:].unsqueeze(1)
+                    c = th.tensor(cal)
+
+                    tup = (o1/o1.max(),o2/o2.max(),o3/o3.max(),o4/o4.max(),m,s,c,co)
+
+                compose = th.cat(tup,0)
+                vutils.save_image(compose, fp = os.path.join(args.out_dir, str(slice_ID)+'_output'+str(i)+".jpg"), nrow = 1, padding = 10)
+        ensres = staple(th.stack(enslist,dim=0)).squeeze(0)
+        vutils.save_image(ensres, fp = os.path.join(args.out_dir, str(slice_ID)+'_output_ens'+".jpg"), nrow = 1, padding = 10)
+
+def create_argparser():
+    defaults = dict(
+        data_name = 'BRATS',
+        data_dir="../dataset/brats2020/testing",
+        clip_denoised=True,
+        num_samples=1,
+        batch_size=1,
+        use_ddim=False,
+        model_path="",         #path to pretrain model
+        num_ensemble=5,      #number of samples in the ensemble
+        gpu_dev = "0",
+        out_dir='./results/',
+        multi_gpu = None, #"0,1,2"
+        debug = False
+    )
+    defaults.update(model_and_diffusion_defaults())
+    parser = argparse.ArgumentParser()
+    add_dict_to_argparser(parser, defaults)
+    return parser
+
+
+if __name__ == "__main__":
+
+    main()

--- a/scripts/ddfm_segmentation_train.py
+++ b/scripts/ddfm_segmentation_train.py
@@ -1,0 +1,125 @@
+
+import sys
+import argparse
+sys.path.append("../")
+sys.path.append("./")
+from guided_diffusion import dist_util, logger
+from guided_diffusion.resample import create_named_schedule_sampler
+from guided_diffusion.bratsloader import BRATSDataset, BRATSDataset3D
+from guided_diffusion.isicloader import ISICDataset
+from guided_diffusion.custom_dataset_loader import CustomDataset,CustomDataset3D
+from guided_diffusion.script_util import (
+    model_and_diffusion_defaults,
+    create_model_and_ddfm,
+    args_to_dict,
+    add_dict_to_argparser,
+)
+import torch as th
+from pathlib import Path
+from guided_diffusion.train_util import TrainLoop
+from visdom import Visdom
+viz = Visdom(port=8850)
+import torchvision.transforms as transforms
+
+def main():
+    args = create_argparser().parse_args()
+
+    dist_util.setup_dist(args)
+    logger.configure(dir = args.out_dir)
+
+    logger.log("creating data loader...")
+
+    if args.data_name == 'ISIC':
+        tran_list = [transforms.Resize((args.image_size,args.image_size)), transforms.ToTensor(),]
+        transform_train = transforms.Compose(tran_list)
+
+        ds = ISICDataset(args, args.data_dir, transform_train)
+        args.in_ch = 4
+    elif args.data_name == 'BRATS':
+        tran_list = [transforms.Resize((args.image_size,args.image_size)),]
+        transform_train = transforms.Compose(tran_list)
+
+        ds = BRATSDataset3D(args.data_dir, transform_train, test_flag=False)
+        args.in_ch = 5
+    elif any(Path(args.data_dir).glob("*\*.nii.gz")):
+        tran_list = [transforms.Resize((args.image_size,args.image_size)),]
+        transform_train = transforms.Compose(tran_list)
+        print("Your current directory : ",args.data_dir)
+        ds = CustomDataset3D(args, args.data_dir, transform_train)
+        args.in_ch = 4
+    else:
+        tran_list = [transforms.Resize((args.image_size,args.image_size)), transforms.ToTensor(),]
+        transform_train = transforms.Compose(tran_list)
+        print("Your current directory : ",args.data_dir)
+        ds = CustomDataset(args, args.data_dir, transform_train)
+        args.in_ch = 4
+        
+    datal= th.utils.data.DataLoader(
+        ds,
+        batch_size=args.batch_size,
+        shuffle=True)
+    data = iter(datal)
+
+    logger.log("creating model and diffusion...")
+
+    model, diffusion = create_model_and_ddfm(
+        **args_to_dict(args, model_and_diffusion_defaults().keys())
+    )
+    if args.multi_gpu:
+        model = th.nn.DataParallel(model,device_ids=[int(id) for id in args.multi_gpu.split(',')])
+        model.to(device = th.device('cuda', int(args.gpu_dev)))
+    else:
+        model.to(dist_util.dev())
+    schedule_sampler = create_named_schedule_sampler(args.schedule_sampler, diffusion,  maxt=args.diffusion_steps)
+
+
+    logger.log("training...")
+    TrainLoop(
+        model=model,
+        diffusion=diffusion,
+        classifier=None,
+        data=data,
+        dataloader=datal,
+        batch_size=args.batch_size,
+        microbatch=args.microbatch,
+        lr=args.lr,
+        ema_rate=args.ema_rate,
+        log_interval=args.log_interval,
+        save_interval=args.save_interval,
+        resume_checkpoint=args.resume_checkpoint,
+        use_fp16=args.use_fp16,
+        fp16_scale_growth=args.fp16_scale_growth,
+        schedule_sampler=schedule_sampler,
+        weight_decay=args.weight_decay,
+        lr_anneal_steps=args.lr_anneal_steps,
+    ).run_loop()
+
+
+def create_argparser():
+    defaults = dict(
+        data_name = 'BRATS',
+        data_dir="../dataset/brats2020/training",
+        schedule_sampler="uniform",
+        lr=1e-4,
+        weight_decay=0.0,
+        lr_anneal_steps=0,
+        batch_size=1,
+        microbatch=-1,  # -1 disables microbatches
+        ema_rate="0.9999",  # comma-separated list of EMA values
+        log_interval=100,
+        save_interval=5000,
+        resume_checkpoint=None, #"/results/pretrainedmodel.pt"
+        use_fp16=False,
+        fp16_scale_growth=1e-3,
+        gpu_dev = "0",
+        multi_gpu = None, #"0,1,2"
+        out_dir='./results/'
+    )
+    defaults.update(model_and_diffusion_defaults())
+    parser = argparse.ArgumentParser()
+    add_dict_to_argparser(parser, defaults)
+    return parser
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add README_DDFM for the new project
- implement `DDFMDiffusion` as a placeholder diffusion process
- support creating a DDFM model and diffusion in `script_util`
- provide training and sampling scripts using the new DDFM diffusion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6853a81cf8108326ba27622c7e23f2ed